### PR TITLE
Archi 4.4 and git plugin 0.6.2.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,18 @@ FROM ubuntu:19.04
 
 MAINTAINER Frederic Auberson <fauberso@dxc.com>
 
-ARG ARCHI_VERSION=4.4.0
-ARG ARCHI_GIT_PLUGIN_VERSION=0.5.2.201907081356
+ARG ARCHI_CHECKSUM=78ef89ac08f
+ARG ARCHI_VERSION=4.6.0
+ARG ARCHI_GIT_PLUGIN_VERSION=0.6.0.202004031233
 ARG ARCHI_USER=archi
 
 RUN apt-get update && apt-get install -y sudo curl unzip libgtk2.0-0 libxtst6 xvfb git && apt-get clean
 
-RUN curl -o /archi.tar.gz https://www.archimatetool.com/downloads/4.4.0/Archi-Linux64-$ARCHI_VERSION.tgz
+RUN curl -o /archi.tar.gz https://www.archimatetool.com/downloads/$ARCHI_CHECKSUM/Archi-Linux64-$ARCHI_VERSION.tgz
 RUN tar -zxvf /archi.tar.gz
 RUN rm /archi.tar.gz
 
-RUN curl -o /archi-git.zip https://www.archimatetool.com/downloads/plugins/org.archicontribs.modelrepository_$ARCHI_GIT_PLUGIN_VERSION.zip
+RUN curl -o /archi-git.zip https://www.archimatetool.com/downloads/plugins/org.archicontribs.modelrepository_$ARCHI_GIT_PLUGIN_VERSION.archiplugin
 RUN unzip /archi-git.zip -d /Archi/plugins
 RUN rm /archi-git.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Frederic Auberson <fauberso@dxc.com>
 
 ARG ARCHI_CHECKSUM=78ef89ac08f
 ARG ARCHI_VERSION=4.6.0
-ARG ARCHI_GIT_PLUGIN_VERSION=0.6.0.202004031233
+ARG ARCHI_GIT_PLUGIN_VERSION=0.6.2.202004031233
 ARG ARCHI_USER=archi
 
 RUN apt-get update && apt-get install -y sudo curl unzip libgtk2.0-0 libxtst6 xvfb git && apt-get clean


### PR DESCRIPTION
Archi 4.4.0 and git plugin 0.6.2. Seems that the https://www.archimatetool.com/ site URL structure for downloads may have changed between versions.

This Dockerfile built successfully for me, see the build log here: https://hub.docker.com/repository/registry-1.docker.io/carldouglas/home/builds/5402f0fc-7a54-47db-bb76-f1b81dfd2859

Thanks